### PR TITLE
Cloning a GitHub Directory into Project

### DIFF
--- a/projects/orderbook/github_utils.py
+++ b/projects/orderbook/github_utils.py
@@ -1,0 +1,15 @@
+import os
+import subprocess
+import shutil
+
+def clone_directory_from_gh(repo_url, commit_id, target_directory, subdirectory):
+    """
+    Clone a subdirectory from a GitHub repo at a specific commit ID.
+    Args:
+        repo_url (str): URL of the GitHub repository.
+        commit_id (str): Commit hash to checkout.
+        target_directory (str): Destination directory to copy the subdirectory into.
+        subdirectory (str): Subdirectory within the repository to copy.
+    """
+    pass
+


### PR DESCRIPTION
Goal: Clone a subdirectory from a GitHub repo at a specific commit ID.
  Args:
      repo_url (str): URL of the GitHub repository.
      commit_id (str): Commit hash to checkout.
      target_directory (str): Destination directory to copy the subdirectory into.
      subdirectory (str): Subdirectory within the repository to copy.